### PR TITLE
Modify Dockerfile & .travis.yml to run docker-compose in CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git*
+log/*
+tmp/*
+Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
-language: ruby
-bundler_args: --without development
+services:
+  - docker
+install: true
 script:
-  - bundle exec rake db:create
-  - bundle exec rake db:schema:load
-  - bundle exec rspec
+  - docker-compose build
+  - docker-compose run web bundle exec rake db:create db:schema:load
+  - docker-compose run web bundle exec rspec
 addons:
   code_climate:
     repo_token: 9b6a47d42b4a745a38818eac18dba4ca94ea88f8c7751859ec49b8cedbf010fe
-rvm:
-  - 2.3.3
 notifications:
   email:
     - social@codebar.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,16 @@
 FROM ruby:2.3.3
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+# Default node version on apt is old. This makes sure a recent version is installed
+# This step also runs apt-get update
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y build-essential libpq-dev nodejs
+# Install PhantomJS for tests - see https://blog.codeship.com/testing-rails-application-docker/
+ENV PHANTOMJS_VERSION=2.1.1
+RUN \
+  cd /usr/local/share && \
+  wget -nv https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 && \
+  tar xvf phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 && \
+  rm phantomjs-${PHANTOMJS_VERSION}-linux-x86_64.tar.bz2 && \
+  ln -s /usr/local/share/phantomjs-${PHANTOMJS_VERSION}-linux-x86_64/bin/phantomjs /usr/local/bin/phantomjs
 RUN mkdir /planner
 WORKDIR /planner
 ADD Gemfile /planner/Gemfile


### PR DESCRIPTION
* skip installing gems because docker
* build and test within docker-compose
* install a recent version of Node, because otherwise PhantomJS
complains
* install PhantomJS so headless tests can run